### PR TITLE
Update test_plm-random-effects.R

### DIFF
--- a/tests/testthat/test_plm-random-effects.R
+++ b/tests/testthat/test_plm-random-effects.R
@@ -25,7 +25,7 @@ test_that("individual effects agree with gls", {
   V_ratio <- Map("/", targetVariance(plm_individual, cluster = Grunfeld$firm),
                  targetVariance(gls_individual, cluster = Grunfeld$firm))
   expect_equal(lapply(V_ratio, min), lapply(V_ratio, max))
-  expect_equivalent(residuals_CS(plm_individual), residuals_CS(gls_individual))
+  expect_equivalent(as.numeric(residuals_CS(plm_individual)), residuals_CS(gls_individual))
 
   CR_plm <- lapply(CR_types, function(x) vcovCR(plm_individual, type = x))
   CR_gls <- lapply(CR_types, function(x) vcovCR(gls_individual, type = x))
@@ -49,7 +49,7 @@ test_that("time effects agree with gls", {
   
   expect_equal(model_matrix(plm_time), model_matrix(gls_time))
   expect_identical(nobs(plm_time), nobs(gls_time))
-  expect_equivalent(residuals_CS(plm_time), residuals_CS(gls_time))
+  expect_equivalent(as.numeric(residuals_CS(plm_time)), residuals_CS(gls_time))
   
   CR_plm <- lapply(CR_types, function(x) vcovCR(plm_time, type = x))
   CR_gls <- lapply(CR_types, function(x) vcovCR(gls_time, type = x))


### PR DESCRIPTION
In the development version of plm 1.6-6, `pmodel.response()` now returns an object of class c("pseries", "numeric"), thus residuals_CS() returns the same classes now for plm objects. Some tests need to be adapted a little.