### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/R/data-documentation.R
+++ b/R/data-documentation.R
@@ -31,7 +31,7 @@
 #' @references Angrist, J. D., & Lavy, V. (2009). The effects of high stakes 
 #'   high school achievement awards : Evidence from a randomized trial.
 #'   \emph{American Economic Review, 99}(4), 1384-1414.
-#'   doi:\href{https://dx.doi.org/10.1257/aer.99.4.1384}{10.1257/aer.99.4.1384}
+#'   doi:\href{https://doi.org/10.1257/aer.99.4.1384}{10.1257/aer.99.4.1384}
 #'   
 
 "AchievementAwardsRCT"
@@ -119,7 +119,7 @@
 #' 
 #' Carpenter, C., & Dobkin, C. (2011). The minimum legal drinking age and public
 #' health. _Journal of Economic Perspectives, 25_(2), 133-156.
-#' doi:[10.1257/jep.25.2.133](https://dx.doi.org/10.1257/jep.25.2.133)
+#' doi:[10.1257/jep.25.2.133](https://doi.org/10.1257/jep.25.2.133)
 #' 
  
 "MortalityRates"
@@ -147,7 +147,7 @@
 #' @references Kalaian, H. A. & Raudenbush, S. W. (1996). A multivariate mixed 
 #'   linear model for meta-analysis. \emph{Psychological Methods, 1}(3),
 #'   227-235. 
-#'   doi:\href{https://dx.doi.org/10.1037/1082-989X.1.3.227}{10.1037/1082-989X.1.3.227}
+#'   doi:\href{https://doi.org/10.1037/1082-989X.1.3.227}{10.1037/1082-989X.1.3.227}
 #'   
 
 "SATcoaching"

--- a/man/AchievementAwardsRCT.Rd
+++ b/man/AchievementAwardsRCT.Rd
@@ -40,6 +40,6 @@ Demonstration program, reported in Angrist & Lavy (2009).
 Angrist, J. D., & Lavy, V. (2009). The effects of high stakes 
   high school achievement awards : Evidence from a randomized trial.
   \emph{American Economic Review, 99}(4), 1384-1414.
-  doi:\href{https://dx.doi.org/10.1257/aer.99.4.1384}{10.1257/aer.99.4.1384}
+  doi:\href{https://doi.org/10.1257/aer.99.4.1384}{10.1257/aer.99.4.1384}
 }
 \keyword{datasets}

--- a/man/MortalityRates.Rd
+++ b/man/MortalityRates.Rd
@@ -36,6 +36,6 @@ cause to effect_. Princeton University Press, 2014.
 
 Carpenter, C., & Dobkin, C. (2011). The minimum legal drinking age and public
 health. _Journal of Economic Perspectives, 25_(2), 133-156.
-doi:[10.1257/jep.25.2.133](https://dx.doi.org/10.1257/jep.25.2.133)
+doi:[10.1257/jep.25.2.133](https://doi.org/10.1257/jep.25.2.133)
 }
 \keyword{datasets}

--- a/man/SATcoaching.Rd
+++ b/man/SATcoaching.Rd
@@ -29,6 +29,6 @@ reported in Kalaian and Raudenbush (1996)
 Kalaian, H. A. & Raudenbush, S. W. (1996). A multivariate mixed 
   linear model for meta-analysis. \emph{Psychological Methods, 1}(3),
   227-235. 
-  doi:\href{https://dx.doi.org/10.1037/1082-989X.1.3.227}{10.1037/1082-989X.1.3.227}
+  doi:\href{https://doi.org/10.1037/1082-989X.1.3.227}{10.1037/1082-989X.1.3.227}
 }
 \keyword{datasets}

--- a/vignettes/meta-analysis-with-CRVE.Rmd
+++ b/vignettes/meta-analysis-with-CRVE.Rmd
@@ -95,9 +95,9 @@ Despite some differences in weighting schemes, the p-value is very close to the 
 
 Fisher, Z., & Tipton, E. (2015). robumeta: An R-package for robust variance estimation in meta-analysis. [arXiv:1503.02220](http://arxiv.org/abs/1503.02220)
 
-Tipton, E. (2015). Small sample adjustments for robust variance estimation with meta-regression. _Psychological Methods, 20_(3), 375-393. doi: [10.1037/met0000011](http://dx.doi.org/10.1037/met0000011)
+Tipton, E. (2015). Small sample adjustments for robust variance estimation with meta-regression. _Psychological Methods, 20_(3), 375-393. doi: [10.1037/met0000011](https://doi.org/10.1037/met0000011)
 
-Tipton, E., & Pustejovsky, J. E. (2015). Small-sample adjustments for tests of moderators and model fit using robust variance estimation in meta-regression. _Journal of Educational and Behavioral Statistics, 40_(6), 604-634. doi: [10.3102/1076998615606099](http://dx.doi.org/10.3102/1076998615606099)
+Tipton, E., & Pustejovsky, J. E. (2015). Small-sample adjustments for tests of moderators and model fit using robust variance estimation in meta-regression. _Journal of Educational and Behavioral Statistics, 40_(6), 604-634. doi: [10.3102/1076998615606099](https://doi.org/10.3102/1076998615606099)
 
 Viechtbauer, W. (2010). Conducting meta-analyses in R with the metafor package. _Journal of Statistical Software, 36_(3), 1-48. URL: http://www.jstatsoft.org/v36/i03/
   

--- a/vignettes/panel-data-CRVE.Rmd
+++ b/vignettes/panel-data-CRVE.Rmd
@@ -198,7 +198,7 @@ Bell, R. M., & McCaffrey, D. F. (2002). Bias reduction in standard errors for li
 
 Cameron, A. C., & Miller, D. L. (2015). A practitioner’s guide to cluster-robust inference. URL: http://cameron.econ.ucdavis.edu/research/Cameron_Miller_JHR_2015_February.pdf
 
-Carpenter, C., & Dobkin, C. (2011). The minimum legal drinking age and public health. _Journal of Economic Perspectives, 25_(2), 133-156. doi: [10.1257/jep.25.2.133](http://dx.doi.org/10.1257/jep.25.2.133)
+Carpenter, C., & Dobkin, C. (2011). The minimum legal drinking age and public health. _Journal of Economic Perspectives, 25_(2), 133-156. doi: [10.1257/jep.25.2.133](https://doi.org/10.1257/jep.25.2.133)
 
 Imbens, G. W., & Kolesar, M. (2015). Robust standard errors in small samples: Some practical advice. URL: https://www.princeton.edu/~mkolesar/papers/small-robust.pdf
 


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!