### PR TITLE
unused argument in call to plm()

### DIFF
--- a/tests/testthat/test_plm-ID-variables.R
+++ b/tests/testthat/test_plm-ID-variables.R
@@ -78,8 +78,7 @@ test_that("plm works for Yuki Takahashi's reprex.",{
   
   fe_fit <- plm(formula = Y ~ Trt, data = Data, 
                 model = "within", index = "id", 
-                effect = "individual", 
-                singular.ok = FALSE)
+                effect = "individual")
   
   
   implicit <- vcovCR(fe_fit, type = "CR2")


### PR DESCRIPTION
`singular.ok` is not an argument to plm(), thus unused. In the current dev version of pkg plm, arguments in ellipsis (dots) are passed on to `pdata.frame` which gives an error in the dev version