### PR TITLE
Fixed a bug in methods for `geepack::geeglm()` models

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Added option to coef_test() to specify one- or two-sided alternative hypotheses.
 * Added options to Wald_test() and coef_test() to specify non-zero values for null hypotheses.
+* Fixed a bug in methods for `geepack::geeglm()` models that occurred for models with nonlinear link functions.
 * Corrected typo in deprecation messages for `impute_covariance_matrix()` and `pattern_covariance_matrix()`.
 
 # clubSandwich 0.5.11

--- a/R/geeglm.R
+++ b/R/geeglm.R
@@ -60,7 +60,7 @@ model_matrix.geeglm <- function(obj) {
   X <- model.matrix(obj)
   eta <- obj$linear.predictors
   dmu_deta <- obj$family$mu.eta
-  d <- dmu_deta(eta)
+  d <- as.vector(dmu_deta(eta))
   d * X
 }
 
@@ -258,3 +258,4 @@ v_scale.geeglm <- function(obj) {
   } 
   as.vector(sum(summary(obj)$df[1:2])) * dispersion
 }
+


### PR DESCRIPTION
Fixed a bug in methods for `geepack::geeglm()` models that occurred for models with nonlinear link functions. Added additional unit tests for geeglm objects using examples from geepack documentation. Closes #102.